### PR TITLE
Count plugins

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -514,6 +514,9 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 	if remoteInfo.Exists("Images") {
 		fmt.Fprintf(cli.out, "Images: %d\n", remoteInfo.GetInt("Images"))
 	}
+	if remoteInfo.Exists("Plugins") {
+		fmt.Fprintf(cli.out, "Plugins: %d\n", remoteInfo.GetInt("Plugins"))
+	}
 	if remoteInfo.Exists("Driver") {
 		fmt.Fprintf(cli.out, "Storage Driver: %s\n", remoteInfo.Get("Driver"))
 	}

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/docker/pkg/parsers/kernel"
 	"github.com/docker/docker/pkg/parsers/operatingsystem"
 	"github.com/docker/docker/pkg/system"
+	"github.com/docker/docker/plugins"
 	"github.com/docker/docker/registry"
 	"github.com/docker/docker/utils"
 )
@@ -67,6 +68,7 @@ func (daemon *Daemon) CmdInfo(job *engine.Job) engine.Status {
 	v := &engine.Env{}
 	v.SetJson("ID", daemon.ID)
 	v.SetInt("Containers", len(daemon.List()))
+	v.SetInt("Plugins", plugins.Repo.CountPlugins())
 	v.SetInt("Images", imgcount)
 	v.Set("Driver", daemon.GraphDriver().String())
 	v.SetJson("DriverStatus", daemon.GraphDriver().Status())

--- a/plugins/repository.go
+++ b/plugins/repository.go
@@ -38,6 +38,11 @@ func NewRepository() *Repository {
 	}
 }
 
+func CountPlugins(repository *Repository) int {
+	// TODO: expand this to include other supported types
+	return len(repository.GetPlugins("volume"))
+}
+
 func (repository *Repository) RegisterPlugin(addr string) error {
 	plugin := &Plugin{addr: addr}
 	resp, err := plugin.handshake()

--- a/plugins/repository.go
+++ b/plugins/repository.go
@@ -40,7 +40,8 @@ func NewRepository() *Repository {
 
 func CountPlugins(repository *Repository) int {
 	// TODO: expand this to include other supported types
-	return len(repository.GetPlugins("volume"))
+	plugins, err := repository.GetPlugins("volume")
+	return len(plugins)
 }
 
 func (repository *Repository) RegisterPlugin(addr string) error {

--- a/plugins/repository.go
+++ b/plugins/repository.go
@@ -38,9 +38,9 @@ func NewRepository() *Repository {
 	}
 }
 
-func CountPlugins(repository *Repository) int {
+func (repository *Repository) CountPlugins() int {
 	// TODO: expand this to include other supported types
-	plugins, err := repository.GetPlugins("volume")
+	plugins, _ := repository.GetPlugins("volume")
 	return len(plugins)
 }
 


### PR DESCRIPTION
In automated testing, it's useful to know when a plugin has been loaded. This PR adds an integral field to `docker info` output which tests can poll to see when plugin handshake succeeds.
